### PR TITLE
Add isort support

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+line_length=100
+known_first_party=todd
+default_section=THIRDPARTY

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 python:
   - "3.6"
 install:
-  - pip install black
+  - pip install black isort
   - pip install -r requirements.txt
 script:
   - black --check .
+  - isort --recursive --check-only .
   - python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,15 @@ todd
 *todd* is an interactive console TODO manager with VI key bindings.
 """
 
+import os
 import sys
+
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
 
 if sys.version_info < (3, 6):
     sys.exit("Please install with Python >= 3.6")
 
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
-import os
 
 with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "todd", "__init__.py")) as fd:
     version = [line.split()[-1].strip('"') for line in fd if line.startswith("version")]

--- a/todd.py
+++ b/todd.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 import sys
 
+from todd.main import main
+
 if sys.version_info < (3, 6):
     sys.exit("Python < 3.6 is not supported")
 
-from todd.main import main
 
 main()

--- a/todd/main.py
+++ b/todd/main.py
@@ -13,18 +13,20 @@ Options:
   --show-default-bindings             Show default keybindings in config parser format
 """
 
+import configparser
+import os
 import sys
+from collections import OrderedDict
+
+from docopt import docopt
+
+import todd
+from todd.tasklib import Tasklist
+from todd.taskui import ColorScheme, KeyBindings, MainUI
 
 if sys.version_info < (3, 6):
     sys.exit("Python < 3.6 is not supported")
 
-import os
-from collections import OrderedDict
-from docopt import docopt
-import todd
-from todd.tasklib import Tasklist
-from todd.taskui import MainUI, ColorScheme, KeyBindings
-import configparser
 
 
 def exit_with_error(message):

--- a/todd/main.py
+++ b/todd/main.py
@@ -28,7 +28,6 @@ if sys.version_info < (3, 6):
     sys.exit("Python < 3.6 is not supported")
 
 
-
 def exit_with_error(message):
     sys.stderr.write(message.strip(" \n") + "\n")
     print(__doc__.split("\n\n")[1])

--- a/todd/tasklib/task.py
+++ b/todd/tasklib/task.py
@@ -1,5 +1,6 @@
-import re
 import datetime
+import re
+
 from todd.tasklib import Util
 
 

--- a/todd/tasklib/tasklist.py
+++ b/todd/tasklib/tasklist.py
@@ -1,7 +1,9 @@
 import os
 import re
+
 import watchdog.events
 import watchdog.observers
+
 from todd.tasklib import Task, Util
 
 

--- a/todd/tasklib/test/todo_test.py
+++ b/todd/tasklib/test/todo_test.py
@@ -1,8 +1,9 @@
-import pytest
 import datetime
-from todd.tasklib import *
-
 import pprint
+
+import pytest
+
+from todd.tasklib import *
 
 pp = pprint.PrettyPrinter(indent=4).pprint
 

--- a/todd/tasklib/util.py
+++ b/todd/tasklib/util.py
@@ -1,5 +1,5 @@
-import re
 import datetime
+import re
 
 
 def _get_today():

--- a/todd/taskui/colorscheme.py
+++ b/todd/taskui/colorscheme.py
@@ -1,5 +1,5 @@
-import os
 import configparser
+import os
 
 
 class ColorScheme:

--- a/todd/taskui/components.py
+++ b/todd/taskui/components.py
@@ -1,4 +1,5 @@
 import urwid
+
 from todd.tasklib.util import Util
 
 

--- a/todd/taskui/main_help.py
+++ b/todd/taskui/main_help.py
@@ -1,6 +1,7 @@
+from textwrap import dedent
+
 import urwid
 
-from textwrap import dedent
 from todd.taskui import ViListBox
 
 

--- a/todd/taskui/main_ui.py
+++ b/todd/taskui/main_ui.py
@@ -1,8 +1,10 @@
-import os
-import urwid
 import collections
-from todd.tasklib import Tasklist, Util
+import os
+
+import urwid
+
 from todd import taskui
+from todd.tasklib import Tasklist, Util
 
 
 class MainUI:

--- a/todd/taskui/taskitem.py
+++ b/todd/taskui/taskitem.py
@@ -1,6 +1,7 @@
 import urwid
-from todd.tasklib import Tasklist, Util
 from urwid_viedit import ViEdit
+
+from todd.tasklib import Tasklist, Util
 
 
 class TaskItem(urwid.WidgetWrap):


### PR DESCRIPTION
This PR will:

1) Add a config file for the isort tool (https://github.com/timothycrosley/isort)
Note - isort does not yet support pyproject.toml in its current release although support has been added in its development branch
2) Add a check to travis to ensure imports are sorted correctly
3) Sort all import statements